### PR TITLE
fix: use named styled import

### DIFF
--- a/src/components/WorkspaceHome.tsx
+++ b/src/components/WorkspaceHome.tsx
@@ -10,7 +10,7 @@ import {
 } from '@sanity/ui'
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {useActiveWorkspace, useWorkspaces} from 'sanity'
-import styled from 'styled-components'
+import {styled} from 'styled-components'
 
 import WorkspacePreview from './WorkspacePreview'
 

--- a/src/components/WorkspacePreview.tsx
+++ b/src/components/WorkspacePreview.tsx
@@ -3,7 +3,7 @@ import {Box, Button, Card, Flex, Grid, Hotkeys, Stack, Text} from '@sanity/ui'
 import React, {createElement, isValidElement, useMemo} from 'react'
 import {isValidElementType} from 'react-is'
 import {useActiveWorkspace, WorkspaceSummary} from 'sanity'
-import styled from 'styled-components'
+import {styled} from 'styled-components'
 
 const createIcon = (icon: React.ComponentType | React.ReactNode) => {
   if (isValidElementType(icon)) return createElement(icon)


### PR DESCRIPTION
### Description

Changes default import of `styled-components` to named `styled` import